### PR TITLE
Scatter shapes across entire background

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,17 +42,22 @@
             () => new THREE.DodecahedronGeometry(0.6)
         ];
 
-        const gridSize = 40; // number of shapes per side
-        const spacing = 1.2;  // distance between shapes
+        const gridSize = 60;      // roughly the size of the cube of shapes
+        const numShapes = 1500;   // total number of shapes to generate
+        const spread = gridSize * 0.8; // area over which to scatter shapes
 
-        for (let i = -gridSize / 2; i < gridSize / 2; i++) {
-            for (let j = -gridSize / 2; j < gridSize / 2; j++) {
-                const geometry = geometries[Math.floor(Math.random() * geometries.length)]();
-                const material = new THREE.MeshStandardMaterial({ color: new THREE.Color().setHSL(Math.random(), 0.7, 0.5) });
-                const mesh = new THREE.Mesh(geometry, material);
-                mesh.position.set(i * spacing, j * spacing, (Math.random() - 0.5) * spacing);
-                group.add(mesh);
-            }
+        for (let s = 0; s < numShapes; s++) {
+            const geometry = geometries[Math.floor(Math.random() * geometries.length)]();
+            const material = new THREE.MeshStandardMaterial({
+                color: new THREE.Color().setHSL(Math.random(), 0.7, 0.5)
+            });
+            const mesh = new THREE.Mesh(geometry, material);
+            mesh.position.set(
+                (Math.random() - 0.5) * spread,
+                (Math.random() - 0.5) * spread,
+                (Math.random() - 0.5) * spread
+            );
+            group.add(mesh);
         }
 
         // Load a font and create a few 3D emoji at random positions
@@ -69,9 +74,9 @@
                 const textMat = new THREE.MeshStandardMaterial({ color: new THREE.Color().setHSL(Math.random(), 0.8, 0.6) });
                 const textMesh = new THREE.Mesh(textGeo, textMat);
                 textMesh.position.set(
-                    (Math.random() - 0.5) * gridSize * spacing,
-                    (Math.random() - 0.5) * gridSize * spacing,
-                    (Math.random() - 0.5) * gridSize * spacing
+                    (Math.random() - 0.5) * spread,
+                    (Math.random() - 0.5) * spread,
+                    (Math.random() - 0.5) * spread
                 );
                 group.add(textMesh);
             });
@@ -79,7 +84,7 @@
 
         scene.add(group);
 
-        camera.position.z = gridSize * spacing;
+        camera.position.z = gridSize;
 
         function animate() {
             requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- fill the WebGL scene with random shapes across 3D space

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68480cb05a208333a4c024b029f7ab8f