### PR TITLE
Enhance towers demo with garden scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,14 +18,23 @@
         <p>Check out <a href="https://www.linkedin.com/in/paul-s-edmunds/" target="_blank" rel="noopener">his LinkedIn profile</a>.</p>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tween.js/18.6.4/tween.umd.js"></script>
     <script>
         const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
-        camera.position.set(0, 8, 18);
+        scene.fog = new THREE.FogExp2(0xcce0ff, 0.02);
+        const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 200);
+        camera.position.set(0, 10, 24);
         const renderer = new THREE.WebGLRenderer({ antialias: true });
         renderer.setSize(window.innerWidth, window.innerHeight);
         document.body.appendChild(renderer.domElement);
+
+        const ground = new THREE.Mesh(
+            new THREE.PlaneGeometry(60, 60),
+            new THREE.MeshStandardMaterial({ color: 0x556b2f })
+        );
+        ground.rotation.x = -Math.PI / 2;
+        scene.add(ground);
 
         const ambient = new THREE.AmbientLight(0xffffff, 0.8);
         scene.add(ambient);
@@ -35,10 +44,21 @@
 
         const board = new THREE.Mesh(
             new THREE.BoxGeometry(16, 0.5, 4),
-            new THREE.MeshStandardMaterial({ color: 0x8b7765 })
+            new THREE.MeshStandardMaterial({ color: 0xdeb887 })
         );
         board.position.y = -0.25;
         scene.add(board);
+
+        const loader = new THREE.GLTFLoader();
+        const fernUrl = 'https://rawcdn.githack.com/mrdoob/three.js/r146/examples/models/gltf/Fern.glb';
+        for (let i = 0; i < 3; i++) {
+            loader.load(fernUrl, gltf => {
+                const fern = gltf.scene;
+                fern.scale.set(5, 5, 5);
+                fern.position.set(-10 + i * 10, 0, -5);
+                scene.add(fern);
+            });
+        }
 
         const pegGeometry = new THREE.CylinderGeometry(0.2, 0.2, 6);
         const pegMaterial = new THREE.MeshStandardMaterial({ color: 0x8b4513 });
@@ -51,7 +71,7 @@
         });
 
         const discHeight = 0.5;
-        const colors = ['#228B22','#2E8B57','#6B8E23','#8FBC8F','#66CDAA','#BDB76B','#DAA520','#FFB6C1'];
+        const colors = [0x8B5A2B,0xA0522D,0xCD853F,0xD2B48C,0xDEB887,0xBC8F8F,0xF4A460,0xCDAA7D];
         const discs = [];
         for (let i = 0; i < 8; i++) {
             const radius = 3 - i * 0.3;
@@ -101,6 +121,17 @@
 
         doMove();
 
+        const rainGeo = new THREE.BufferGeometry();
+        const rainCount = 1000;
+        const rainPos = [];
+        for (let i = 0; i < rainCount; i++) {
+            rainPos.push((Math.random() - 0.5) * 60, Math.random() * 20 + 10, (Math.random() - 0.5) * 60);
+        }
+        rainGeo.setAttribute('position', new THREE.Float32BufferAttribute(rainPos, 3));
+        const rainMat = new THREE.PointsMaterial({ color: 0xaaaaaa, size: 0.1 });
+        const rain = new THREE.Points(rainGeo, rainMat);
+        scene.add(rain);
+
         function resetGame() {
             moveIndex = 0;
             moves.length = 0;
@@ -118,6 +149,12 @@
         function animate(time) {
             requestAnimationFrame(animate);
             TWEEN.update(time);
+            const pos = rain.geometry.attributes.position.array;
+            for (let i = 0; i < pos.length; i += 3) {
+                pos[i + 1] -= 0.2;
+                if (pos[i + 1] < 0) pos[i + 1] = Math.random() * 20 + 10;
+            }
+            rain.geometry.attributes.position.needsUpdate = true;
             renderer.render(scene, camera);
         }
         animate();


### PR DESCRIPTION
## Summary
- add GLTF loader for external models
- create fog, ground plane and reposition camera
- switch board and disc palette to wood tones
- load three fern models and add gentle rain particles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a8b4b4c588333a44ab60b20053170